### PR TITLE
サロゲートペアを扱うテストケースを追加

### DIFF
--- a/src/test/java/nablarch/fw/messaging/handler/HttpMessagingResponseBuildingHandlerTest.java
+++ b/src/test/java/nablarch/fw/messaging/handler/HttpMessagingResponseBuildingHandlerTest.java
@@ -269,7 +269,7 @@ public class HttpMessagingResponseBuildingHandlerTest {
             <statusCode>200</statusCode>
           </_nbctlhdr>
           <result>
-            <msg>succes\ns</msg>
+            <msg>🙀🙀🙀succes🙀🙀🙀\ns</msg>
           </result>
         </response>
          ****************************/
@@ -294,7 +294,7 @@ public class HttpMessagingResponseBuildingHandlerTest {
 
         // ダミー業務クラスで返却する応答データ
         Map<String, Object> resObj = new HashMap<String, Object>();
-        resObj.put("result.msg", "succes\\ns");
+        resObj.put("result.msg", "🙀🙀🙀succes🙀🙀🙀\\ns");
 
         LogVerifier.setExpectedLogMessages(createExpectedLogMessages(requestTelegram, createResponseData(responseTelegram, "UTF-8", responseFormatFile)));
 
@@ -372,7 +372,7 @@ public class HttpMessagingResponseBuildingHandlerTest {
             "statusCode":"200"
           }
           "result":{
-            "msg":" success \n"
+            "msg":" 🙀🙀🙀success🙀🙀🙀 \n"
           }
         }
         ****************************/
@@ -397,7 +397,7 @@ public class HttpMessagingResponseBuildingHandlerTest {
 
         // ダミー業務クラスで返却する応答データ
         Map<String, Object> resObj = new HashMap<String, Object>();
-        resObj.put("result.msg", " success \n");
+        resObj.put("result.msg", " 🙀🙀🙀success🙀🙀🙀 \n");
 
         // 期待値
         LogVerifier.setExpectedLogMessages(createExpectedLogMessages(requestTelegram, createResponseData(responseTelegram, "UTF-8", responseFormatFile)));

--- a/src/test/java/nablarch/fw/messaging/handler/HttpMessagingResponseBuildingHandlerTest.java
+++ b/src/test/java/nablarch/fw/messaging/handler/HttpMessagingResponseBuildingHandlerTest.java
@@ -236,6 +236,7 @@ public class HttpMessagingResponseBuildingHandlerTest {
           <user>
             <id>nablarch</id>
             <name>ナブラーク</name>
+            <surrogatepair>🙀🙀🙀</surrogatepair>
             <cno>1234567890123456</cno>
           </user>
         </request>
@@ -255,6 +256,7 @@ public class HttpMessagingResponseBuildingHandlerTest {
         [user]
         1 id            X
         2 name          X
+        3 surrogatepair X
         ****************************/
         requestFormatFile.deleteOnExit();
 
@@ -338,7 +340,8 @@ public class HttpMessagingResponseBuildingHandlerTest {
           }
           "user":{
             "id":"nablarch",
-            "name":"ナブラーク"
+            "name":"ナブラーク",
+            "surrogatepair":"🙀🙀🙀"
           }
         }
         ****************************/
@@ -357,6 +360,7 @@ public class HttpMessagingResponseBuildingHandlerTest {
         [user]
         1 id            X
         2 name          X
+        3 surrogatepair X
         ****************************/
         requestFormatFile.deleteOnExit();
 

--- a/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpMessagingClientTest.java
+++ b/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpMessagingClientTest.java
@@ -301,7 +301,10 @@ public class HttpMessagingClientTest {
         requestRecodeData = new TreeMap<String, Object>();
         requestRecodeData.put("requestId", "RM21AB0201");
         requestRecodeData.put("firstName", "太郎");
-        requestRecodeData.put("lastName", "ナブラ \n");
+        requestRecodeData.put("lastName", "ナブラ");
+        // サロゲートペア対応
+        requestRecodeData.put("surrogatepair", "🙀🙀🙀 \n");
+
         requestMessage.addDataRecord(requestRecodeData);
         reqHeaderRecord = new TreeMap<String, Object>();
         reqHeaderRecord.put("X-xx", null);//意地悪なデータとして、わざとnullを設定する。nullはフレームワーク側で空文字列に置換する。
@@ -342,7 +345,7 @@ public class HttpMessagingClientTest {
         
         LogVerifier.setExpectedLogMessages(
                 createExpectedLogMessages(
-                        "{\"requestId\":\"RM21AB0201\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ \\n\"}",
+                        "{\"requestId\":\"RM21AB0201\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ\",\"surrogatepair\":\"🙀🙀🙀 \\n\"}",
                         "POST http://localhost:8090/rm21ab0201",
                         "{\"messageCode\":\"100\", \"message\":\"OK\"}",
                         200));
@@ -350,7 +353,7 @@ public class HttpMessagingClientTest {
         reciveMessage = client.sendSync(settings, requestMessage);
         
         assertThat(client.getLastUri(), is("http://localhost:8090/rm21ab0201"));
-        assertThat(client.getLastBodyText(), is("{\"requestId\":\"RM21AB0201\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ \\n\"}"));
+        assertThat(client.getLastBodyText(), is("{\"requestId\":\"RM21AB0201\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ\",\"surrogatepair\":\"🙀🙀🙀 \\n\"}"));
         assertThat(client.getLastCharset(), is("UTF-8"));
         assertThat(client.getLastHttpMethod(), is(HttpRequestMethodEnum.POST));
         headerRecord = reciveMessage.getHeaderRecord();
@@ -437,6 +440,7 @@ public class HttpMessagingClientTest {
         1 requestId X
         2 firstName N
         3 lastName N
+        4 surrogatepair N
         *******/
         formatFile.deleteOnExit();
         
@@ -546,6 +550,8 @@ public class HttpMessagingClientTest {
         recodeData.put("requestId", "RM21AB0301");
         recodeData.put("firstName", "太郎");
         recodeData.put("lastName", "ナブラ");
+        // サロゲートペア対応
+        recodeData.put("surrogatepair", "🙀🙀🙀");
         requestMessage.addDataRecord(recodeData);
         settings = new MessageSenderSettings(requestMessage.getRequestId());
         //応答を差し替えるためにスタブをインスタンス化する。
@@ -577,7 +583,7 @@ public class HttpMessagingClientTest {
         
         LogVerifier.setExpectedLogMessages(
                 createExpectedLogMessages(
-                        "{\"requestId\":\"RM21AB0301\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ\"}",
+                        "{\"requestId\":\"RM21AB0301\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ\",\"surrogatepair\":\"🙀🙀🙀\"}",
                         "PUT http://localhost:8090/rm21ab0301",
                         "{\"messageCode\":\"100\", \"message\":\"OK\"}",
                         200));
@@ -585,7 +591,7 @@ public class HttpMessagingClientTest {
         reciveMessage = client.sendSync(settings, requestMessage);
         
         assertThat(client.getLastUri(), is("http://localhost:8090/rm21ab0301"));
-        assertThat(client.getLastBodyText(), is("{\"requestId\":\"RM21AB0301\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ\"}"));
+        assertThat(client.getLastBodyText(), is("{\"requestId\":\"RM21AB0301\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ\",\"surrogatepair\":\"🙀🙀🙀\"}"));
         assertThat(client.getLastCharset(), is("UTF-8"));
         assertThat(client.getLastHttpMethod(), is(HttpRequestMethodEnum.PUT));
         headerRecord = reciveMessage.getHeaderRecord();
@@ -620,6 +626,7 @@ public class HttpMessagingClientTest {
         1 requestId X
         2 firstName N
         3 lastName N
+        4 surrogatepair N
         *******/
         formatFile.deleteOnExit();
         

--- a/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpMessagingClientTest.java
+++ b/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpMessagingClientTest.java
@@ -334,7 +334,7 @@ public class HttpMessagingClientTest {
                         map.put(null, arrayList);
                         httpResult.setHeaderInfo(map);
                         httpResult.setResponseCode(200);
-                        String readObject = "{\"messageCode\":\"100\", \"message\":\"OK\"}";
+                        String readObject = "{\"messageCode\":\"100\", \"message\":\"🙀🙀🙀OK🙀🙀🙀\"}";
                         httpResult.setReadObject(readObject);
                         return httpResult;
                     }
@@ -347,7 +347,7 @@ public class HttpMessagingClientTest {
                 createExpectedLogMessages(
                         "{\"requestId\":\"RM21AB0201\",\"firstName\":\"太郎\",\"lastName\":\"ナブラ\",\"surrogatepair\":\"🙀🙀🙀 \\n\"}",
                         "POST http://localhost:8090/rm21ab0201",
-                        "{\"messageCode\":\"100\", \"message\":\"OK\"}",
+                        "{\"messageCode\":\"100\", \"message\":\"🙀🙀🙀OK🙀🙀🙀\"}",
                         200));
         
         reciveMessage = client.sendSync(settings, requestMessage);
@@ -361,7 +361,7 @@ public class HttpMessagingClientTest {
         assertThat((String)(headerRecord.get("Content-Type")), is("application/json; charset=UTF-8"));
         dataRecord = reciveMessage.getDataRecord();
         assertThat((String)(dataRecord.get("messageCode")), is("100"));
-        assertThat((String)(dataRecord.get("message")), is("OK"));
+        assertThat((String)(dataRecord.get("message")), is("🙀🙀🙀OK🙀🙀🙀"));
 
         LogVerifier.verify("messaging log assertion failed.");
         

--- a/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpProtocolBasicClientTest.java
+++ b/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpProtocolBasicClientTest.java
@@ -268,13 +268,15 @@ public class HttpProtocolBasicClientTest {
 
         //record-separatorあり固定長の複数レコード
         requestBody = StringUtil.rpad("RM21AB0203", 20, ' ') + StringUtil.rpad("太郎", 10, '　') + StringUtil.rpad("ナブラ", 10, '　') + StringUtil.repeat(' ', 40) + "\n"
-                    + StringUtil.rpad("RM21AB0203", 20, ' ') + StringUtil.rpad("太郎", 10, '　') + StringUtil.rpad("ナブラ", 10, '　') + StringUtil.repeat(' ', 40) + "\n";
+                    + StringUtil.rpad("RM21AB0203", 20, ' ') + StringUtil.rpad("太郎", 10, '　') + StringUtil.rpad("ナブラ", 10, '　') + StringUtil.repeat(' ', 40) + "\n"
+        //サロゲートペア対応
+                    + StringUtil.rpad("RM21AB0203", 20, ' ') + StringUtil.rpad("🙀🙀🙀", 10, '　') + StringUtil.rpad("🙀🙀🙀", 10, '　') + StringUtil.repeat(' ', 40) + "\n";
         expectedResponseBody = "100" + StringUtil.rpad("OK", 50, ' ') + StringUtil.repeat(' ', 47) + "\n"
                              + "100" + StringUtil.rpad("OK", 50, ' ') + StringUtil.repeat(' ', 47) + "\n";
         streamReader = new CharHttpStreamReader();
         urlParams = new HashMap<String, String>();
         headerInfo = new HashMap<String, List<String>>();
-        streamWriter = new CharHttpStreamWritter("MS932");
+        streamWriter = new CharHttpStreamWritter("UTF-8");
         streamWriter.append(requestBody);
         httpProtocolBasicClient = new HttpProtocolBasicClient();
         httpResult = httpProtocolBasicClient.execute(HttpRequestMethodEnum.POST,
@@ -824,9 +826,10 @@ public class HttpProtocolBasicClientTest {
             while((len = is.read(buf)) > 0) {
                 baos.write(buf, 0, len);
             }
-            String requestBody = baos.toString("MS932");
+            String requestBody = baos.toString("UTF-8");
             String expectedRequestBody = StringUtil.rpad("RM21AB0203", 20, ' ') + StringUtil.rpad("太郎", 10, '　') + StringUtil.rpad("ナブラ", 10, '　') + StringUtil.repeat(' ', 40) + "\n"
-                                       + StringUtil.rpad("RM21AB0203", 20, ' ') + StringUtil.rpad("太郎", 10, '　') + StringUtil.rpad("ナブラ", 10, '　') + StringUtil.repeat(' ', 40) + "\n";
+                                       + StringUtil.rpad("RM21AB0203", 20, ' ') + StringUtil.rpad("太郎", 10, '　') + StringUtil.rpad("ナブラ", 10, '　') + StringUtil.repeat(' ', 40) + "\n"
+                                       + StringUtil.rpad("RM21AB0203", 20, ' ') + StringUtil.rpad("🙀🙀🙀", 10, '　') + StringUtil.rpad("🙀🙀🙀", 10, '　') + StringUtil.repeat(' ', 40) + "\n";
             assertThat(requestBody, is(expectedRequestBody));
             
             String responseBody = "100" + StringUtil.rpad("OK", 50, ' ') + StringUtil.repeat(' ', 47) + "\n"


### PR DESCRIPTION
HttpMessagingResponseBuildingHandlerTestにJSONとXMLの正常系テストを追加し、httpProtocolBasicClientやStubHTTPMessagingClientを使ってメッセージの内容を確認するテストを追加しました