### PR TITLE
test: Java 14 以上でもテストが通るように修正

### DIFF
--- a/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpProtocolBasicClientTest.java
+++ b/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpProtocolBasicClientTest.java
@@ -99,7 +99,9 @@ public class HttpProtocolBasicClientTest {
                     "http:://localhost:8766/action/010.do", headerInfo, null, null, null);
             fail();
         } catch (Exception e) {
-            assertThat(e.getClass().getName(), is(RuntimeException.class.getName()));
+            // Java 14 でJDKの内部実装が変わりスローされる例外が変化したことに対応するため、実行時の Java のバージョンによって期待する例外を切り替えている
+            Class<?> expectedException = isJava14OrLater() ? HttpMessagingException.class : RuntimeException.class;
+            assertThat(e.getClass().getName(), is(expectedException.getName()));
         }
         // スキームの後ろの/を多く
         try {
@@ -107,7 +109,9 @@ public class HttpProtocolBasicClientTest {
                     "http:///localhost:8766/action/010.do", headerInfo, null, null, null);
             fail();
         } catch (Exception e) {
-            assertThat(e.getClass().getName(), is(RuntimeException.class.getName()));
+            // Java 14 でJDKの内部実装が変わりスローされる例外が変化したことに対応するため、実行時の Java のバージョンによって期待する例外を切り替えている
+            Class<?> expectedException = isJava14OrLater() ? HttpMessagingException.class : RuntimeException.class;
+            assertThat(e.getClass().getName(), is(expectedException.getName()));
         }
         // 不正なホスト名
         try {
@@ -132,6 +136,20 @@ public class HttpProtocolBasicClientTest {
             fail();
         } catch (Exception e) {
             assertThat(e.getClass().getName(), is(HttpMessagingException.class.getName()));
+        }
+    }
+
+    /**
+     * 実行環境の JVM のバージョンが 14 以上であるかどうか判定する。
+     * @return Java 14 以上で実行されている場合は true
+     */
+    private static boolean isJava14OrLater() {
+        try {
+            // Java 14 で追加された API があるかどうかで、 Java 14 以上かどうかを判断する
+            Class.forName("jdk.jfr.consumer.RecordingStream");
+            return true;
+        } catch (ClassNotFoundException e) {
+            return false;
         }
     }
     


### PR DESCRIPTION
`HttpUrlConnection` の内部実装が Java 14 で変わり、 URL の書式誤りによるエラーがあったときに `IllegalArgumentException` ではなく `IOException` をスローするようになった。

`IllegalArgumentException` の場合は非検査例外なのでそのままテストの呼び出し元まで例外が届き、 `RuntimeException` かどうかで検証されていた。
一方で、 `IOException` がスローされた場合はテスト対象の `HttpProtocolBasicClient` がキャッチして `HttpMessagingException` に詰めて再スローするため、テストの呼び出し元に届く例外が変化した。

Java 14 以上かどうかを実行時に判断して、期待する例外の型を切り替えることで対応。
Java 14 かどうかは、 Java 14 で新規追加された API ([jdk.jfr.consumer.RecordingStream](https://docs.oracle.com/en/java/javase/17/docs/api/jdk.jfr/jdk/jfr/consumer/RecordingStream.html)) が存在するかどうか判定するようにした。
（システムプロパティから取れるバージョンはフォーマットの仕様が良く分からないのと、文字列なので「14 以上」の判定が難しいと判断したため）

```log
[ERROR]   HttpProtocolBasicClientTest.testAbnormalURL:102
Expected: is "java.lang.RuntimeException"
     but: was "nablarch.fw.messaging.realtime.http.exception.HttpMessagingException"
```