### PR TITLE
test: Java 14 前後で振る舞いの変わるテストの実装方法を修正

### DIFF
--- a/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpProtocolBasicClientTest.java
+++ b/src/test/java/nablarch/fw/messaging/realtime/http/client/HttpProtocolBasicClientTest.java
@@ -35,6 +35,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -99,9 +100,12 @@ public class HttpProtocolBasicClientTest {
                     "http:://localhost:8766/action/010.do", headerInfo, null, null, null);
             fail();
         } catch (Exception e) {
-            // Java 14 でJDKの内部実装が変わりスローされる例外が変化したことに対応するため、実行時の Java のバージョンによって期待する例外を切り替えている
-            Class<?> expectedException = isJava14OrLater() ? HttpMessagingException.class : RuntimeException.class;
-            assertThat(e.getClass().getName(), is(expectedException.getName()));
+            // Java 14 でJDKの内部実装が変わりスローされる例外が変化したことに対応するため、
+            // RuntimeException(14未満) か HttpMessagingException(14以上) のいずれかで検証している
+            assertThat(e.getClass().getName(), anyOf(
+                is(RuntimeException.class.getName()),
+                is(HttpMessagingException.class.getName())
+            ));
         }
         // スキームの後ろの/を多く
         try {
@@ -109,9 +113,12 @@ public class HttpProtocolBasicClientTest {
                     "http:///localhost:8766/action/010.do", headerInfo, null, null, null);
             fail();
         } catch (Exception e) {
-            // Java 14 でJDKの内部実装が変わりスローされる例外が変化したことに対応するため、実行時の Java のバージョンによって期待する例外を切り替えている
-            Class<?> expectedException = isJava14OrLater() ? HttpMessagingException.class : RuntimeException.class;
-            assertThat(e.getClass().getName(), is(expectedException.getName()));
+            // Java 14 でJDKの内部実装が変わりスローされる例外が変化したことに対応するため、
+            // RuntimeException(14未満) か HttpMessagingException(14以上) のいずれかで検証している
+            assertThat(e.getClass().getName(), anyOf(
+                is(RuntimeException.class.getName()),
+                is(HttpMessagingException.class.getName())
+            ));
         }
         // 不正なホスト名
         try {
@@ -136,20 +143,6 @@ public class HttpProtocolBasicClientTest {
             fail();
         } catch (Exception e) {
             assertThat(e.getClass().getName(), is(HttpMessagingException.class.getName()));
-        }
-    }
-
-    /**
-     * 実行環境の JVM のバージョンが 14 以上であるかどうか判定する。
-     * @return Java 14 以上で実行されている場合は true
-     */
-    private static boolean isJava14OrLater() {
-        try {
-            // Java 14 で追加された API があるかどうかで、 Java 14 以上かどうかを判断する
-            Class.forName("jdk.jfr.consumer.RecordingStream");
-            return true;
-        } catch (ClassNotFoundException e) {
-            return false;
         }
     }
     


### PR DESCRIPTION
わざわざ Java のバージョン判定をしなくても、いずれかの例外であることをテストすれば十分ではないかという指摘を受けて対応。